### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/LabTerminal/reticle/security/code-scanning/1](https://github.com/LabTerminal/reticle/security/code-scanning/1)

To fix this, explicitly declare minimal `GITHUB_TOKEN` permissions in the workflow so jobs do not rely on repository defaults. Since the jobs only check out code, install dependencies, and build, they only need read access to repository contents.

The best fix with no functional changes is to add a root-level `permissions` block (applies to all jobs) right after the `name: CI` line. Set `contents: read`, which is the minimal suggested starting point and sufficient for `actions/checkout` and `actions/cache` to function. No job appears to need write access to contents, issues, or pull requests, so no additional scopes are necessary.

Concretely:
- Edit `.github/workflows/ci.yml`.
- After line 1 (`name: CI`), insert:
  ```yaml
  permissions:
    contents: read
  ```
- Leave the rest of the workflow unchanged; no imports or additional methods are needed since this is pure YAML configuration.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
