### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/LabTerminal/reticle/security/code-scanning/2](https://github.com/LabTerminal/reticle/security/code-scanning/2)

In general, fix this by explicitly defining `permissions:` for the workflow or for the specific jobs so that the `GITHUB_TOKEN` has only the scopes required. For a CI workflow that only checks and builds code, `contents: read` is typically sufficient. You can set it once at the top level so it applies to all jobs that don’t override it.

The best targeted fix here is to add a root-level `permissions:` block directly under the `name: CI` line in `.github/workflows/ci.yml`, specifying `contents: read`. None of the jobs perform operations that need write access (no pushes, releases, PR updates, etc.), and `actions/checkout@v4` and `actions/cache@v4` both function correctly with read-only contents. This leaves existing functionality unchanged while ensuring the GITHUB_TOKEN is scoped minimally and silencing the CodeQL warning about the `frontend` job (and the others).

Concretely:
- Edit `.github/workflows/ci.yml`.
- Insert:

  ```yaml
  permissions:
    contents: read
  ```

  after line 1 (`name: CI`) and before the `on:` block.
- No imports or additional methods are needed, as this is purely YAML configuration.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
