### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 


### PR DESCRIPTION
Potential fix for [https://github.com/LabTerminal/reticle/security/code-scanning/3](https://github.com/LabTerminal/reticle/security/code-scanning/3)

In general, fix this by adding an explicit `permissions` section that restricts the `GITHUB_TOKEN` to the minimal required scope. You can set this at the top level of the workflow (applies to all jobs without their own `permissions`) or per job. Since none of the jobs appears to need write access, we can safely use `contents: read` only.

The single best fix here is to add a top-level `permissions` block right after the `on:` section (or after `env:`) in `.github/workflows/ci.yml`. This will apply to `check`, `frontend`, and `build`, limiting the token to read-only access to repository contents. No imports, methods, or other definitions are needed, and no existing steps require modification, because `actions/checkout`, `actions/cache`, and the other actions work fine with `contents: read` for this use case (building, formatting, linting, and type-checking).

Concretely:
- Edit `.github/workflows/ci.yml`.
- Insert:

  ```yaml
  permissions:
    contents: read
  ```

  between the `on:` block and the `env:` block (around original lines 8–9).  
- Leave all jobs (`check`, `frontend`, `build`) unchanged; they will inherit this restricted permission set.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
