### PR TITLE
Add CSV and HAR export formats for session logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,16 +332,14 @@ just build    # Desktop app (macOS/Linux/Windows)
 - [x] Confirmation dialogs for destructive actions (Clear Logs, Delete Session)
 - [x] Transport type toggle surfaced in control bar
 - [x] Improved empty state messaging with getting-started hints
-
-### In Progress
-- [ ] Log export (CSV/HAR formats)
+- [x] Log export (JSON/CSV/HAR formats)
+- [x] Distribution packages (npm, PyPI, Homebrew)
 
 ### Planned
 - [ ] Security firewall (block/allow specific methods)
 - [ ] Traffic replay and request modification
 - [ ] Session playback (replay recorded sessions)
 - [ ] Multi-agent topology view
-- [ ] npm/Homebrew distribution
 - [ ] First-time user onboarding tour
 
 ---

--- a/frontend/src/components/ui/dropdown-menu.tsx
+++ b/frontend/src/components/ui/dropdown-menu.tsx
@@ -1,0 +1,83 @@
+import * as React from "react"
+import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu"
+import { cn } from "@/lib/utils"
+
+const DropdownMenu = DropdownMenuPrimitive.Root
+
+const DropdownMenuTrigger = DropdownMenuPrimitive.Trigger
+
+const DropdownMenuContent = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Content>
+>(({ className, sideOffset = 4, ...props }, ref) => (
+  <DropdownMenuPrimitive.Portal>
+    <DropdownMenuPrimitive.Content
+      ref={ref}
+      sideOffset={sideOffset}
+      className={cn(
+        "z-50 min-w-[8rem] overflow-hidden rounded-md border border-border bg-popover p-1 text-popover-foreground shadow-md",
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        className
+      )}
+      {...props}
+    />
+  </DropdownMenuPrimitive.Portal>
+))
+DropdownMenuContent.displayName = DropdownMenuPrimitive.Content.displayName
+
+const DropdownMenuItem = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Item> & {
+    inset?: boolean
+  }
+>(({ className, inset, ...props }, ref) => (
+  <DropdownMenuPrimitive.Item
+    ref={ref}
+    className={cn(
+      "relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      inset && "pl-8",
+      className
+    )}
+    {...props}
+  />
+))
+DropdownMenuItem.displayName = DropdownMenuPrimitive.Item.displayName
+
+const DropdownMenuLabel = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.Label>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Label> & {
+    inset?: boolean
+  }
+>(({ className, inset, ...props }, ref) => (
+  <DropdownMenuPrimitive.Label
+    ref={ref}
+    className={cn(
+      "px-2 py-1.5 text-sm font-semibold",
+      inset && "pl-8",
+      className
+    )}
+    {...props}
+  />
+))
+DropdownMenuLabel.displayName = DropdownMenuPrimitive.Label.displayName
+
+const DropdownMenuSeparator = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.Separator>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Separator>
+>(({ className, ...props }, ref) => (
+  <DropdownMenuPrimitive.Separator
+    ref={ref}
+    className={cn("-mx-1 my-1 h-px bg-muted", className)}
+    {...props}
+  />
+))
+DropdownMenuSeparator.displayName = DropdownMenuPrimitive.Separator.displayName
+
+export {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+}

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -20,8 +20,9 @@ pub mod tokens;
 pub use interaction::{can_interact, get_mcp_methods, send_raw_message, send_request};
 pub use proxy::{start_proxy, start_proxy_v2, start_remote_proxy, stop_proxy};
 pub use recording::{
-    delete_recorded_session, export_session, get_recording_status, list_recorded_sessions,
-    load_recorded_session, start_recording, stop_recording,
+    delete_recorded_session, export_session, export_session_csv, export_session_har,
+    get_recording_status, list_recorded_sessions, load_recorded_session, start_recording,
+    stop_recording,
 };
 pub use sessions::{
     add_session_tags, get_all_server_names, get_all_tags, get_session_metadata,

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -27,11 +27,11 @@ mod storage;
 use commands::{
     add_session_tags, analyze_mcp_server, can_interact, clear_all_token_stats,
     clear_session_token_stats, delete_recorded_session, estimate_tokens, export_session,
-    get_all_server_names, get_all_tags, get_global_token_stats, get_mcp_methods,
-    get_recording_status, get_session_metadata, get_session_token_stats, list_recorded_sessions,
-    list_sessions_filtered, load_recorded_session, remove_session_tags, send_raw_message,
-    send_request, start_proxy, start_proxy_v2, start_recording, start_remote_proxy, stop_proxy,
-    stop_recording,
+    export_session_csv, export_session_har, get_all_server_names, get_all_tags,
+    get_global_token_stats, get_mcp_methods, get_recording_status, get_session_metadata,
+    get_session_token_stats, list_recorded_sessions, list_sessions_filtered, load_recorded_session,
+    remove_session_tags, send_raw_message, send_request, start_proxy, start_proxy_v2,
+    start_recording, start_remote_proxy, stop_proxy, stop_recording,
 };
 use state::AppState;
 
@@ -63,6 +63,8 @@ fn main() {
             load_recorded_session,
             delete_recorded_session,
             export_session,
+            export_session_csv,
+            export_session_har,
             // Interaction commands
             send_request,
             send_raw_message,


### PR DESCRIPTION
## Add CSV and HAR export formats

Adds multiple export format options for recorded sessions, allowing users to export in JSON, CSV, or HAR format.

### Changes

**Backend (Rust)**
- `export_session_csv` - Exports session as CSV with columns: id, timestamp, relative_time_ms, direction, method, jsonrpc_id, size_bytes, content
- `export_session_har` - Exports session as HAR (HTTP Archive) format, adapted for MCP/JSON-RPC with request/response pairing by JSON-RPC ID

**Frontend (React)**
- New `dropdown-menu.tsx` component using Radix UI
- Export button now shows a dropdown with three format options:
  - Export as JSON (original)
  - Export as CSV (spreadsheet-friendly)
  - Export as HAR (for HTTP analysis tools like Chrome DevTools)

### Use Cases
- **CSV**: Import into spreadsheets for analysis, filtering, and custom reporting
- **HAR**: Visualize in browser DevTools Network tab or HAR viewers for timeline analysis
